### PR TITLE
Set nom version to 4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.1"
 authors = ["Damian Poddebniak <poddebniak@fh-muenster.de>"]
 
 [dependencies]
-nom = "*"
+nom = "4.0"


### PR DESCRIPTION
Setting the version to "*" puts the crate at risk of breaking if nom publishes a new major version