### PR TITLE
Use nom 7.0.0-alpha1 and abnf-core 0.5.0 to avoid issues with dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "abnf"
 description = "A nom-based parser for ABNF."
-version = "0.11.3"
+version = "0.12.0"
 authors = ["Damian Poddebniak <poddebniak@fh-muenster.de>"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
@@ -11,8 +11,8 @@ repository = "https://github.com/duesee/abnf"
 keywords = ["abnf", "parser", "nom"]
 
 [dependencies]
-nom = "6"
-abnf-core = "0.4"
+nom = "7.0.0-alpha1"
+abnf-core = "0.5.0"
 
 [dev-dependencies]
 quickcheck        = "0.8"


### PR DESCRIPTION
Hi there! 

Follow up on PR to https://github.com/duesee/abnf-core/pull/3. Reasons for the bump are described in the `abnf-core` PR.
Should be merged (if merged) only after `abnf-core` is updated and published to crates.io because of dependency on bumped version. 

Tested on this branch with cargo git imports: https://github.com/damirka/abnf/tree/bump-nom-crate